### PR TITLE
Update readme file to choose the correct accessKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lf-sample-repository-api-nodejs
 
-Sample node service app that connects to a Laserfiche Cloud or Self-Hosted Repository.
+Sample Node service app that connects to a Laserfiche Cloud or Self-Hosted Repository.
 [Sample Code](./index.ts)
 
 ## Cloud Prerequisites
@@ -19,7 +19,7 @@ Sample node service app that connects to a Laserfiche Cloud or Self-Hosted Repos
   - [CA Cloud](https://app.laserfiche.ca/laserfiche)
   - [EU Cloud](https://app.eu.laserfiche.com/laserfiche)
   - [US Cloud](https://app.laserfiche.com/laserfiche)
-  
+
 - Using the app picker, go to the 'Account' page
 - Click on the 'Service Principals' tab
 - Click on the 'Add Service Principal' button to create an account to be used to run this sample service

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ Sample node service app that connects to a Laserfiche Cloud or Self-Hosted Repos
 ### 1. Create a Service Principal
 
 - Log in to your account using Web Client as an administrator:
+
   - [CA Cloud](https://app.laserfiche.ca/laserfiche)
   - [EU Cloud](https://app.eu.laserfiche.com/laserfiche)
   - [US Cloud](https://app.laserfiche.com/laserfiche)
+  
 - Using the app picker, go to the 'Account' page
 - Click on the 'Service Principals' tab
 - Click on the 'Add Service Principal' button to create an account to be used to run this sample service
@@ -35,7 +37,9 @@ Sample node service app that connects to a Laserfiche Cloud or Self-Hosted Repos
 - Select the 'Service' option, enter a name, and click the 'Create application' button
 - Select the app service account to be the one created on step 1 and click the 'Save changes' button
 - Click on the 'Authentication' Tab and create a new Access Key
+- Select the first option (i.e. Create a public 'Access Key'...)
 - Click the 'Download key as base-64 string' button for later use
+- Click OK
 
 ### 3. Clone this repo on your local machine
 


### PR DESCRIPTION
Update the readme file to choose the correct accessKey
Added spacing to the links like the java readme file 
Should match the instructions in the java sample project -> https://github.com/Laserfiche/lf-sample-repository-api-java/blob/2.x/README.md#2-create-an-oauth-service-app